### PR TITLE
docs: use `field-group` & `field` component in args section

### DIFF
--- a/docs/2.generators/badges.md
+++ b/docs/2.generators/badges.md
@@ -28,15 +28,43 @@ The `badges` generator generates badges for the latest npm version, npm download
 
 ## Arguments
 
-- `name`: The npm package name. By default tries to infer from `package.json`.
-- `github`: Github repository name. By default tries to infer from `package.json`.
-- `license`: Show license badge (requires `github`).
-- `licenseBranch`: Branch to use for license badge defaults to `main`.
-- `bundlephobia`: Show [Bundlephobia](https://bundlephobia.com/) badge (requires `name`).
-- `codecov`: Enable [Codecov](https://codecov.io) badge (requires `github`).
-- `no-npmDownloads`: Hide npm downloads badge.
-- `no-npmVersion`: Hide npm version badge.
-- `provider`: Can be one of `shields` (for [shields.io](https://shields.io/)) or `badgen` / `badgenClassic` (for [badgen.net](https://badgen.net/)). Default is `badgen`.
+::field-group
+    ::field{name="name" type="string"}
+    The npm package name. By default tries to infer from `package.json`
+    ::
+
+    ::field{name="github" type="string"}
+    Github repository name. By default tries to infer from `package.json`
+    ::
+
+    ::field{name="license" type="boolean"}
+    Show license badge (requires `github`)
+    ::
+
+    ::field{name="licenseBranch" type="string"}
+    Branch to use for license badge defaults to `main`
+    ::
+
+    ::field{name="bundlephobia" type="boolean"}
+    Show [Bundlephobia](https://bundlephobia.com/) badge (requires `name`)
+    ::
+
+    ::field{name="codecov" type="boolean"}
+    Enable [Codecov](https://codecov.io) badge (requires `github`)
+    ::
+
+    ::field{name="no-npmDownloads" type="boolean"}
+    Hide npm downloads badge
+    ::
+
+    ::field{name="no-npmVersion" type="boolean"}
+    Hide npm version badge
+    ::
+
+    ::field{name="provider" type="string"}
+    Can be one of `shields` (for [shields.io](https://shields.io/)) or `badgen` / `badgenClassic` (for [badgen.net](https://badgen.net/)). Default is `badgen`.
+    ::
+::
 
 > [!TIP]
 > You can use additional args `color`, `labelColor` to customize style. For provider specific params, use `styleParams`.

--- a/docs/2.generators/contributors.md
+++ b/docs/2.generators/contributors.md
@@ -28,8 +28,24 @@ The `contributors` generator generates an image of contributors using [contrib.r
 
 ## Arguments
 
-- `github`: Github repository name (by default tries to read from `package.json`)
-- `max`: Max contributor count (100 by default)
-- `anon` Include anonymous users (false by default)
-- `author`: Comma separated list of github usersnames.
-- `license`: Name of license.
+::field-group
+    ::field{name="github" type="string"}
+    Github repository name (by default tries to read from `package.json`)
+    ::
+
+    ::field{name="max" type="number"}
+    Max contributor count (100 by default)
+    ::
+
+    ::field{name="anon" type="boolean"}
+    Include anonymous users (false by default)
+    ::
+
+    ::field{name="author" type="string"}
+    Comma separated list of github usersnames.
+    ::
+
+    ::field{name="license" type="string"}
+    Name of license.
+    ::
+::

--- a/docs/2.generators/fetch.md
+++ b/docs/2.generators/fetch.md
@@ -29,7 +29,11 @@ The `fetch` generator fetches a URL (using [unjs/ofetch](https://ofetch.unjs.io)
 
 ## Arguments
 
-- `url`: The URL to fetch from
+::field-group
+    ::field{name="url" type="string"}
+    The URL to fetch from
+    ::
+::
 
 > [!TIP]
 > You can start url with `gh:` to use github contents!

--- a/docs/2.generators/file.md
+++ b/docs/2.generators/file.md
@@ -29,4 +29,8 @@ The `file` generator reads a file and inlines it's contents.
 
 ## Arguments
 
-- `src`: Relative path to the file.
+::field-group
+    ::field{name="src" type="string"}
+    Relative path to the file.
+    ::
+::

--- a/docs/2.generators/jsdocs.md
+++ b/docs/2.generators/jsdocs.md
@@ -46,6 +46,16 @@ Internally it uses [untyped](https://untyped.unjs.io/) and [jiti](https://github
 
 ## Arguments
 
-- `src`: Path to the source file. The default is `./src/index` and can be omitted.
-- `headingLevel`: Nested level for markdown group headings (default is `2` => `##`). Note: Each function uses `headingLevel+1` for the title in nested levels.
-- `group`: Only render function exports annotated with `@group name`. By default, there is no group filter. Value can be a string or an array of strings.
+::field-group
+    ::field{name="src" type="string"}
+    Path to the source file. The default is `./src/index` and can be omitted.
+    ::
+
+    ::field{name="headingLevel" type="number"}
+    Nested level for markdown group headings (default is `2` => `##`). Note: Each function uses `headingLevel+1` for the title in nested levels.
+    ::
+
+    ::field{name="group" type="string"}
+    Only render function exports annotated with `@group name`. By default, there is no group filter. Value can be a string or an array of strings.
+    ::
+::

--- a/docs/2.generators/jsimport.md
+++ b/docs/2.generators/jsimport.md
@@ -43,7 +43,7 @@ The `jsimport` generator generates JavaScript usage example to be imported.
     ::field{name="name" type="string"}
     The package name (by default tries to read from the `name` field in `package.json`).
     ::
-    ::field{name="import" type="string"}
+    ::field{name="import/imports" type="string"}
     Array or comma seperated list of export names.
     ::
     ::field{name="no-esm" type="boolean"}

--- a/docs/2.generators/jsimport.md
+++ b/docs/2.generators/jsimport.md
@@ -39,10 +39,26 @@ The `jsimport` generator generates JavaScript usage example to be imported.
 
 ## Arguments
 
-- `name`: The package name (by default tries to read from the `name` field in `package.json`).
-- `import`/`imports`: Array or comma seperated list of export names.
-- `no-esm`: Disable ESM instructions.
-- `cdn`: Generate CDN import usage.
-- `cjs`: Generate CommonJS require usage.
-- `src`: Auto scan export names from src using [unjs/mlly](https://mlly.unjs.io).
-- `printWidth`: The maximum length that requires wrapping lines. Default is `80`
+::field-group
+    ::field{name="name" type="string"}
+    The package name (by default tries to read from the `name` field in `package.json`).
+    ::
+    ::field{name="import" type="string"}
+    Array or comma seperated list of export names.
+    ::
+    ::field{name="no-esm" type="boolean"}
+    Disable ESM instructions.
+    ::
+    ::field{name="cdn" type="boolean"}
+    Generate CDN import usage.
+    ::
+    ::field{name="cjs" type="boolean"}
+    Generate CommonJS require usage.
+    ::
+    ::field{name="src" type="boolean"}
+    Auto scan export names from src using [unjs/mlly](https://mlly.unjs.io).
+    ::
+    ::field{name="printWidth" type="number"}
+    The maximum length that requires wrapping lines. Default is `80`
+    ::
+::

--- a/docs/2.generators/pm-install.md
+++ b/docs/2.generators/pm-install.md
@@ -38,8 +38,20 @@ The `pm-install` or `pm-i` generator generates installation commands for several
 
 ## Arguments
 
-- `name`: The package name (by default tries to read from the `name` field in `package.json`).
-- `dev`: Install as a dev dependency (defaults to `false`).
-- `separate`: Separate code blocks for each package manager (defaults to `false`).
-- `auto`: Auto-detect package manager using [unjs/nypm](https://github.com/unjs/nypm#-nypm) (defaults to `true`).
-- `version`: Show version in install command
+::field-group
+    ::field{name="name" type="string"}
+    The package name (by default tries to read from the `name` field in `package.json`).
+    ::
+    ::field{name="dev" type="boolean"}
+    Install as a dev dependency (defaults to `false`).
+    ::
+    ::field{name="separate" type="boolean"}
+    Separate code blocks for each package manager (defaults to `false`).
+    ::
+    ::field{name="auto" type="boolean"}
+    Auto-detect package manager using [unjs/nypm](https://github.com/unjs/nypm#-nypm) (defaults to `true`).
+    ::
+    ::field{name="version" type="boolean"}
+    Show version in install command
+    ::
+::

--- a/docs/2.generators/pm-x.md
+++ b/docs/2.generators/pm-x.md
@@ -32,7 +32,17 @@ The `pm-x` generator generates commands for running/executing a package through 
 
 ## Arguments
 
-- `name`: The package name (by default tries to read from the `name` field in `package.json`).
-- `separate`: Separate code blocks for each package manager (defaults to `false`).
-- `args`: An additional string appended at the end of each command suggesting arguments to be used with the program. (defaults to `""`).
-- `version`: Show version in exec command
+::field-group
+    ::field{name="name" type="string"}
+    The package name (by default tries to read from the `name` field in `package.json`).
+    ::
+    ::field{name="separate" type="boolean"}
+    Separate code blocks for each package manager (defaults to `false`).
+    ::
+    ::field{name="args" type="string"}
+    An additional string appended at the end of each command suggesting arguments to be used with the program. (defaults to `""`).
+    ::
+    ::field{name="version" type="boolean"}
+    Show version in exec command
+    ::
+::

--- a/docs/2.generators/with-automd.md
+++ b/docs/2.generators/with-automd.md
@@ -25,5 +25,11 @@ The `with-automd` generator generates a benner that notifies docs are updated wi
 
 ## Arguments
 
-- `lastUpdate`: Show last updated date. (use string for static value)
-- `no-separator`: Disable addition of separator `---`
+::field-group
+    ::field{name="lastUpdate" type="string"}
+    Show last updated date. (use string for static value)
+    ::
+    ::field{name="no-separator" type="boolean"}
+    Disable addition of separator `---`
+    ::
+::


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#36 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves: #36 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
