### PR TITLE
fix: `version` should be obtained automatically when set to `true`

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -19,7 +19,7 @@ export async function getPkg(dir: string, input: Record<string, string> = {}) {
   return defu(
     {
       name: input.name,
-      version: typeof input.version === 'string' ? input.version : null,
+      version: typeof input.version === 'string' ? input.version : undefined,
       github: input.github || input.gh,
     },
     {

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -19,7 +19,7 @@ export async function getPkg(dir: string, input: Record<string, string> = {}) {
   return defu(
     {
       name: input.name,
-      version: input.version,
+      version: typeof input.version === 'string' ? input.version : null,
       github: input.github || input.gh,
     },
     {

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -19,7 +19,7 @@ export async function getPkg(dir: string, input: Record<string, string> = {}) {
   return defu(
     {
       name: input.name,
-      version: typeof input.version === 'string' ? input.version : undefined,
+      version: typeof input.version === "string" ? input.version : undefined,
       github: input.github || input.gh,
     },
     {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Output 'true' when used without a value, Like:

    <!-- automd:pm-install version -->
    
    ```sh
    # ✨ Auto-detect
    npx nypm install automd@^true
    
    # npm
    npm install automd@^true
    
    # yarn
    yarn add automd@^true
    
    # pnpm
    pnpm install automd@^true
    
    # bun
    bun install automd@^true
    ```
    
    <!-- /automd -->



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
