### PR TITLE
Add src-link generator

### DIFF
--- a/docs/2.generators/pm-x.md
+++ b/docs/2.generators/pm-x.md
@@ -8,25 +8,25 @@ The `pm-x` generator generates commands for running/executing a package through 
 
 ### Input
 
-    <!-- automd:pm-x version="latest" name="package-name" args="\"[files]" <flags>" -->
+    <!-- automd:pm-x version="latest" name="package-name" args="[files] <flags>" -->
     <!-- /automd -->
 
 ### Output
 
-    <!-- automd:pm-x version="latest" name="package-name" args="\"[files]" <flags>" -->
+    <!-- automd:pm-x version="latest" name="package-name" args="[files] <flags>" -->
 
     ```sh
     # npm
-    npx package-name@latest "[files]
+    npx package-name@latest [files] <flags>
 
     # pnpm
-    pnpm dlx package-name@latest "[files]
+    pnpm dlx package-name@latest [files] <flags>
 
     # bun
-    bunx package-name@latest "[files]
+    bunx package-name@latest [files] <flags>
 
     # deno
-    deno run -A npm:package-name@latest "[files]
+    deno run -A npm:package-name@latest [files] <flags>
     ```
 
     <!-- /automd -->

--- a/docs/2.generators/src-link.md
+++ b/docs/2.generators/src-link.md
@@ -1,0 +1,50 @@
+# src-link
+
+The `src-link` generator creates a Markdown link to the lines matching a string or regular expression in a local or GitHub source file.
+
+## Example
+
+<!-- automd:example generator=src-link src="../../test/fixture/TEST.md" pattern="Lazy Coder's Guide" label="fixture source" -->
+
+### Input
+
+    <!-- automd:src-link src="../../test/fixture/TEST.md" pattern="Lazy Coder's Guide" label="fixture source" -->
+    <!-- /automd -->
+
+### Output
+
+    <!-- automd:src-link src="../../test/fixture/TEST.md" pattern="Lazy Coder's Guide" label="fixture source" -->
+
+    [fixture source](../../test/fixture/TEST.md#L1)
+
+    <!-- /automd -->
+
+<!-- /automd -->
+
+## Arguments
+
+::field-group
+
+::field{name="src" type="string"}
+The local path or GitHub source. GitHub sources can use a full URL or the `gh:owner/repo/blob/ref/path` shorthand.
+::
+
+::field{name="pattern" type="string"}
+The text to find. Wrap the value in `/.../flags` to use a regular expression.
+::
+
+::field{name="label" type="string"}
+The link text.
+::
+
+::
+
+## Usage
+
+```markdown
+<!-- automd:src-link src="gh:nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts" pattern="/export interface NuxtHooks/" label="Nuxt hooks source" -->
+
+[Nuxt hooks source](https://github.com/nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts#L110)
+
+<!-- /automd -->
+```

--- a/src/_parse.ts
+++ b/src/_parse.ts
@@ -85,10 +85,12 @@ export function containsAutomd(md: string) {
 export function parseRawArgs(rawArgs: string) {
   const args = Object.create(null);
 
-  for (const part of rawArgs.split(/\s+/)) {
-    const [_key, value] = part.split("=");
+  for (const part of rawArgs.match(/(?:[^\s"]+|"(?:\\.|[^"\\])*")+/g) || []) {
+    const separatorIndex = part.indexOf("=");
+    const _key = separatorIndex === -1 ? part : part.slice(0, separatorIndex);
+    const value = separatorIndex === -1 ? undefined : part.slice(separatorIndex + 1);
     const key = _key && camelCase(_key);
-    if (key && value) {
+    if (key && value !== undefined) {
       args[key] = destr(value);
     } else if (part.startsWith("no-")) {
       args[part.slice(3)] = false;

--- a/src/generators/index.ts
+++ b/src/generators/index.ts
@@ -8,6 +8,7 @@ import { withAutomd } from "./with-automd.ts";
 import { file } from "./file.ts";
 import { contributors } from "./contributors.ts";
 import { dirTree } from "./dir-tree.ts";
+import { srcLink } from "./src-link.ts";
 
 export default {
   jsdocs,
@@ -21,4 +22,5 @@ export default {
   "with-automd": withAutomd,
   contributors,
   "dir-tree": dirTree,
+  "src-link": srcLink,
 } as Record<string, Generator>;

--- a/src/generators/src-link.ts
+++ b/src/generators/src-link.ts
@@ -1,0 +1,102 @@
+import { readFile } from "node:fs/promises";
+import { defineGenerator } from "../generator.ts";
+import { resolvePath } from "../_utils.ts";
+
+export const srcLink = defineGenerator({
+  name: "src-link",
+  async generate({ args, config, url }) {
+    const { src, pattern, label } = args;
+    if (![src, pattern, label].every((value) => typeof value === "string" && value)) {
+      throw new Error("src, pattern, and label are required arguments");
+    }
+
+    let link = src;
+    let contents: string;
+
+    if (src.startsWith("gh:") || src.startsWith("https://github.com/")) {
+      const githubSource = resolveGitHubSource(src);
+      link = githubSource.link;
+      try {
+        const { $fetch } = await import("ofetch");
+        contents = await $fetch<string>(githubSource.raw);
+      } catch (error) {
+        return {
+          contents: `[${label}](${link})`,
+          issues: [`Failed to fetch file: ${link}. ${error}`],
+        };
+      }
+    } else if (/^https?:\/\//.test(src)) {
+      return {
+        contents: `[${label}](${src}#:~:text=${encodeURIComponent(pattern)})`,
+      };
+    } else {
+      try {
+        contents = await readFile(resolvePath(src, { url, dir: config.dir }), "utf8");
+      } catch (error) {
+        return {
+          contents: `[${label}](${link})`,
+          issues: [`Failed to read local file: ${link}. ${error}`],
+        };
+      }
+    }
+
+    const matches = [...contents.matchAll(parsePattern(pattern))];
+    const matchedLines = matches.map((match) => lineNumber(contents, match.index));
+
+    if (matches.length === 0) {
+      return {
+        contents: `[${label}](${link})`,
+        issues: [`Pattern "${pattern}" not found in the file: ${link}`],
+      };
+    }
+
+    if (matches.length > 1) {
+      return {
+        contents: `[${label}](${link})`,
+        issues: [
+          `Multiple matches found for pattern "${pattern}" in the file: ${link}. Matches found at lines: ${matchedLines.join(", ")}`,
+        ],
+      };
+    }
+
+    const match = matches[0]!;
+    const startLine = matchedLines[0]!;
+    const endLine = lineNumber(contents, match.index + Math.max(match[0].length - 1, 0));
+    const lines = startLine === endLine ? `L${startLine}` : `L${startLine}-L${endLine}`;
+
+    return {
+      contents: `[${label}](${link}#${lines})`,
+    };
+  },
+});
+
+function resolveGitHubSource(src: string) {
+  const path = src.startsWith("gh:") ? src.slice(3) : new URL(src).pathname.slice(1);
+  const segments = path.split("/").filter(Boolean);
+  if (segments[2] === "blob") {
+    segments.splice(2, 1);
+  }
+  if (segments.length < 4) {
+    throw new Error(`Invalid GitHub source: ${src}`);
+  }
+
+  const [owner, repo, ref, ...file] = segments;
+  return {
+    link: `https://github.com/${owner}/${repo}/blob/${ref}/${file.join("/")}`,
+    raw: `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${file.join("/")}`,
+  };
+}
+
+function parsePattern(pattern: string) {
+  const match = /^\/([\s\S]*)\/([dgimsuvy]*)$/.exec(pattern);
+  if (!match) {
+    return new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+  }
+
+  const flags = match[2]!.includes("g") ? match[2]! : `${match[2]}g`;
+  return new RegExp(match[1]!, flags);
+}
+
+function lineNumber(contents: string, index: number) {
+  return contents.slice(0, index).split("\n").length;
+}

--- a/test/fixture/INPUT.md
+++ b/test/fixture/INPUT.md
@@ -40,6 +40,14 @@
 <!-- automd:file src="./TEST.md" lines=1:5 -->
 <!-- /automd -->
 
+## `src-link`
+
+<!-- automd:src-link src="./TEST.md" pattern="Lazy Coder's Guide" label="fixture source" -->
+<!-- /automd -->
+
+<!-- automd:src-link src="gh:unjs/automd/blob/main/test/fixture/TEST.md" pattern="/Programming can be hard[\\s\\S]*compiler's fault/i" label="remote fixture source" -->
+<!-- /automd -->
+
 ## `contributors`
 
 <!-- automd:contributors author=pi0 license=MIT -->

--- a/test/fixture/OUTPUT.md
+++ b/test/fixture/OUTPUT.md
@@ -201,6 +201,20 @@ When your code doesn't work, don't blame yourself. It's clearly the compiler's f
 
 <!-- /automd -->
 
+## `src-link`
+
+<!-- automd:src-link src="./TEST.md" pattern="Lazy Coder's Guide" label="fixture source" -->
+
+[fixture source](./TEST.md#L1)
+
+<!-- /automd -->
+
+<!-- automd:src-link src="gh:unjs/automd/blob/main/test/fixture/TEST.md" pattern="/Programming can be hard[\\s\\S]*compiler's fault/i" label="remote fixture source" -->
+
+[remote fixture source](https://github.com/unjs/automd/blob/main/test/fixture/TEST.md#L3-L5)
+
+<!-- /automd -->
+
 ## `contributors`
 
 <!-- automd:contributors author=pi0 license=MIT -->

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -7,6 +7,7 @@ describe("parseRawArgs", () => {
     [`no-foo`, { foo: false }],
     [`foo="bar"`, { foo: "bar" }],
     [`foo=bar`, { foo: "bar" }],
+    [`foo="bar baz" query="a=b c"`, { foo: "bar baz", query: "a=b c" }],
     [`a-key=a-value another-key=another-value`, { aKey: "a-value", anotherKey: "another-value" }],
   ] as const;
   for (const [input, expected] of tests) {


### PR DESCRIPTION
This PR introduces a new generator called `src-link` for AutoMD. The generator allows users to create Markdown links to specific lines in source code files:

Examples: 

<details><summary>GitHub URLs</summary>
<p>

```md
<!-- automd:src-link url="gh:nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts" pattern="export interface NuxtHooks {" label="schema source code" -->
<!-- /automd -->
``` 

Will produce:

```md
[schema source code](https://github.com/nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts#L83)
```

</p>
</details> 

<details><summary>GitHub URLs with Regex</summary>
<p>

```md
<!-- automd:src-link url="gh:nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts" pattern="Kit[^}]*'kit:compatibility" label="Kit compatibility" -->
<!-- /automd -->
``` 

Will produce:

```md
[Kit compatibility](https://github.com/nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts#L84-L91)
```

</p>
</details> 

<details><summary>Relative URLs</summary>
<p>

```md
<!-- automd:src-link url="./types/hooks.ts" pattern="export interface NuxtHooks {" label="schema source code" -->
<!-- /automd -->
``` 

Will produce:

```md
[schema source code](./types/hooks.ts:83)
```

</p>
</details> 


Check the test cases to see more options.

Related #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `src-link` generator that creates links to matching lines in local files, GitHub sources, and other URLs.
  * Supports custom labels, regular expression patterns, source formats, and clear error reporting.
* **Bug Fixes**
  * Corrected generated command arguments in the `pm-x` documentation.
  * Improved handling of quoted values, embedded equals signs, and explicitly empty arguments.
* **Documentation**
  * Added comprehensive `src-link` usage examples and supported-source guidance.
* **Tests**
  * Added coverage for argument parsing and generated local and remote source links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->