### PR TITLE
feat(file): trim contents by default

### DIFF
--- a/docs/2.generators/file.md
+++ b/docs/2.generators/file.md
@@ -40,7 +40,6 @@ The `file` generator reads a file and inlines it's contents.
     subkey: "value",
     },
     };
-
     ```
 
     <!-- /automd -->

--- a/docs/2.generators/file.md
+++ b/docs/2.generators/file.md
@@ -66,4 +66,6 @@ Code lang.
 File name in code. Use `no-name` to disable name in code.
 ::
 
+::field{name="noTrim" type="boolean"}
+Don't trim the file contents.
 ::

--- a/docs/2.generators/file.md
+++ b/docs/2.generators/file.md
@@ -40,6 +40,7 @@ The `file` generator reads a file and inlines it's contents.
     subkey: "value",
     },
     };
+
     ```
 
     <!-- /automd -->

--- a/src/generators/file.ts
+++ b/src/generators/file.ts
@@ -9,7 +9,9 @@ export const file = defineGenerator({
   async generate({ args, config, url }) {
     const fullPath = resolvePath(args.src, { url, dir: config.dir });
     let contents = await readFile(fullPath, "utf8");
-    contents = contents.trim();
+    if (!args.noTrim) {
+      contents = contents.trim();
+    }
 
     if (args.code) {
       contents = md.codeBlock(

--- a/src/generators/file.ts
+++ b/src/generators/file.ts
@@ -9,6 +9,7 @@ export const file = defineGenerator({
   async generate({ args, config, url }) {
     const fullPath = resolvePath(args.src, { url, dir: config.dir });
     let contents = await readFile(fullPath, "utf8");
+    contents = contents.trim();
 
     if (args.code) {
       contents = md.codeBlock(


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

While generating code examples we read the whole file. Formatters like Prettier adds additional line at the end of these files. But when you import that content into a code block, the same formatter is removing it.
Trimming the file content is preventing from the regeneration of the examples when they haven't really changed :)
