### PR TITLE
fix(pm, pm-install): add `npm:` prefix for deno

### DIFF
--- a/docs/2.generators/pm-install.md
+++ b/docs/2.generators/pm-install.md
@@ -32,7 +32,7 @@ The `pm-install` or `pm-i` generator generates installation commands for several
     bun install -D package-name
 
     # deno
-    deno install --dev package-name
+    deno install --dev npm:package-name
     ```
 
     <!-- /automd -->

--- a/src/generators/pm.ts
+++ b/src/generators/pm.ts
@@ -7,7 +7,7 @@ const INSTALL_COMMANDS = [
   ["yarn", "add"],
   ["pnpm", "install"],
   ["bun", "install"],
-  ["deno", "install", " --dev"],
+  ["deno", "install", " --dev", "npm:"],
 ] as const;
 
 const NYPM_COMMAND = ["npx nypm", "install"] as const;
@@ -42,9 +42,9 @@ export const pmInstall = defineGenerator({
         : [NYPM_COMMAND, ...INSTALL_COMMANDS];
 
     const contents = commands.map(
-      ([cmd, install, dev = " -D"]) =>
+      ([cmd, install, dev = " -D", pkgPrefix = ""]) =>
         // prettier-ignore
-        `# ${cmd.includes("nypm") ? "✨ Auto-detect" : cmd}\n${cmd} ${install}${args.dev ? dev : (args.global ? "g" : "")} ${name}${versionSuffix}`,
+        `# ${cmd.includes("nypm") ? "✨ Auto-detect" : cmd}\n${cmd} ${install}${args.dev ? dev : (args.global ? "g" : "")} ${pkgPrefix}${name}${versionSuffix}`,
     );
 
     if ((args.separate ?? false) === false) {

--- a/test/fixture/OUTPUT.md
+++ b/test/fixture/OUTPUT.md
@@ -62,7 +62,7 @@ bun install -D automd
 
 ```sh
 # deno
-deno install --dev automd
+deno install --dev npm:automd
 ```
 
 <!-- /automd -->


### PR DESCRIPTION
## issue

resolve #114 

## description

I modified the `pm-install` generator to include the `npm:` prefix in the Deno install command, ensuring that it now generates a valid command.

