### PR TITLE
feat(badges): add npmx.dev as a badge provider

### DIFF
--- a/src/generators/badges.ts
+++ b/src/generators/badges.ts
@@ -66,6 +66,16 @@ const badgeProviders: Record<string, BadgeProvider> = {
     codecov: "https://badgen.net/codecov/c/github/{github}",
     license: "https://badgen.net/github/license/{github}",
   },
+  // https://docs.npmx.dev/guide/features#custom-badges
+  npmx: {
+    npmVersion: "https://npmx.dev/api/registry/badge/version/{name}",
+    npmDownloads: "https://npmx.dev/api/registry/badge/downloads-month/{name}",
+    bundlephobia: false,
+    bundlejs: false,
+    packagephobia: "https://npmx.dev/api/registry/badge/size/{name}",
+    codecov: false,
+    license: "https://npmx.dev/api/registry/badge/license/{name}",
+  },
 };
 
 export const badges = defineGenerator({

--- a/test/fixture/INPUT.md
+++ b/test/fixture/INPUT.md
@@ -5,6 +5,9 @@
 <!-- automd:badges bundlephobia packagephobia  -->
 <!-- /automd -->
 
+<!-- automd:badges provider=npmx license packagephobia -->
+<!-- /automd -->
+
 ## `pm-x`
 
 <!-- automd:pm-x args=. -->

--- a/test/fixture/OUTPUT.md
+++ b/test/fixture/OUTPUT.md
@@ -11,6 +11,15 @@
 
 <!-- /automd -->
 
+<!-- automd:badges provider=npmx license packagephobia -->
+
+[![npm version](https://npmx.dev/api/registry/badge/version/automd)](https://npmjs.com/package/automd)
+[![npm downloads](https://npmx.dev/api/registry/badge/downloads-month/automd)](https://npm.chart.dev/automd)
+[![install size](https://npmx.dev/api/registry/badge/size/automd)](https://packagephobia.com/result?p=automd)
+[![license](https://npmx.dev/api/registry/badge/license/automd)](https://github.com/unjs/automd/blob/main/LICENSE)
+
+<!-- /automd -->
+
 ## `pm-x`
 
 <!-- automd:pm-x args=. -->


### PR DESCRIPTION
Adds `npmx.dev` as a new provider option for the `badges` generator, sourcing badge images from https://npmx.dev/api/registry/badge/.

Badge type mappings:
- `npmVersion`   → /badge/version/{name}
- `npmDownloads` → /badge/downloads-month/{name} (monthly, consistent with shields' npm/dm)
- `packagephobia` → /badge/size/{name} (install/unpacked size)
- `license`      → /badge/license/{name}

Existing customization args (`color`, `labelColor`, `styleParams`) are forwarded as query directly.

Usage:

```md
  <!-- automd:badges provider=npmx license packagephobia -->
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npmx badge provider for displaying npm package information including version, downloads, license, and packagephobia metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->