### PR TITLE
docs: fix 'seperated' typo in jsimport generator docs

### DIFF
--- a/docs/2.generators/jsimport.md
+++ b/docs/2.generators/jsimport.md
@@ -46,7 +46,7 @@ The package name (by default tries to read from the `name` field in `package.jso
 ::
 
 ::field{name="import/imports" type="string"}
-Array or comma seperated list of export names.
+Array or comma separated list of export names.
 ::
 
 ::field{name="no-esm" type="boolean"}


### PR DESCRIPTION
Noticed `seperated` instead of `separated` in `docs/2.generators/jsimport.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the `import/imports` argument description documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/automd/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->