### PR TITLE
fix: keep expanded CLI input files

### DIFF
--- a/src/automd.ts
+++ b/src/automd.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fsp } from "node:fs";
+import { existsSync, promises as fsp, statSync } from "node:fs";
 import { resolve, relative, dirname } from "pathe";
 import type { SubscribeCallback } from "@parcel/watcher";
 import { pathToFileURL } from "mlly";
@@ -63,7 +63,7 @@ export async function automd(_config: Config = {}): Promise<AutomdReturn> {
   } else {
     inputFiles = inputFiles
       .map((i) => resolve(config.dir, i))
-      .filter((i) => existsSync(i))
+      .filter((i) => existsSync(i) && statSync(i).isFile())
       .map((i) => relative(config.dir, i));
   }
   const multiFiles = inputFiles.length > 1;

--- a/src/cli-input.ts
+++ b/src/cli-input.ts
@@ -1,0 +1,10 @@
+export function normalizeCliInput(input?: string | string[], positionals: string[] = []) {
+  return [...toArray(input), ...positionals]
+    .flatMap((i) => i.split(","))
+    .map((i) => i.trim())
+    .filter(Boolean);
+}
+
+function toArray(value?: string | string[]) {
+  return Array.isArray(value) ? value : value ? [value] : [];
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import consola from "consola";
 import { colorize } from "consola/utils";
 import pkg from "../package.json" with { type: "json" };
 import { type AutomdResult, automd } from "./automd.ts";
+import { normalizeCliInput } from "./cli-input.ts";
 import { type ResolvedConfig } from "./config.ts";
 
 const main = defineCommand({
@@ -36,7 +37,7 @@ const main = defineCommand({
   async setup({ args }) {
     const { results, config, time } = await automd({
       dir: args.dir,
-      input: args.input?.split(",").map((i) => i.trim()),
+      input: normalizeCliInput(args.input, args._),
       output: args.output,
       watch: args.watch,
       onWatch: (event) => {

--- a/test/automd.test.ts
+++ b/test/automd.test.ts
@@ -1,4 +1,7 @@
 import { fileURLToPath } from "node:url";
+import { promises as fsp } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { expect, describe, it } from "vitest";
 import { format } from "prettier";
 import { automd } from "../src/index.ts";
@@ -23,5 +26,27 @@ describe("automd generators", () => {
 
   it("is formatted", async () => {
     expect(await format(output, { parser: "markdown" })).toEqual(output);
+  });
+
+  it("ignores directories from expanded input lists", async () => {
+    const dir = await fsp.mkdtemp(join(tmpdir(), "automd-dir-input-"));
+
+    try {
+      await fsp.copyFile(
+        fileURLToPath(new URL("fixture/INPUT.md", import.meta.url)),
+        join(dir, "INPUT.md"),
+      );
+      await fsp.mkdir(join(dir, "src"));
+
+      const { results } = await automd({
+        dir,
+        input: ["INPUT.md", "src"],
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]!.input).toBe(join(dir, "INPUT.md"));
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/cli-input.test.ts
+++ b/test/cli-input.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCliInput } from "../src/cli-input.ts";
+
+describe("normalizeCliInput", () => {
+  it("keeps shell-expanded input arguments", () => {
+    expect(normalizeCliInput("content/a.md", ["content/b.md"])).toEqual([
+      "content/a.md",
+      "content/b.md",
+    ]);
+  });
+
+  it("splits comma-separated input values", () => {
+    expect(normalizeCliInput("content/a.md, content/b.md")).toEqual([
+      "content/a.md",
+      "content/b.md",
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #139.

This keeps CLI `--input` handling aligned with the `automd()` API when the shell expands a glob before it reaches the CLI.

Changes:

- Preserve extra positional values that come from shell-expanded `--input` globs, so `--input content/a.md content/b.md` processes both files.
- Continue supporting comma-separated input values.
- Ignore directories in explicit input lists, which prevents `EISDIR` when a shell-expanded pattern such as `content/**/*` includes directories.

Verification:

- `pnpm exec vitest run test/cli-input.test.ts test/automd.test.ts`
- `pnpm exec vitest run --coverage`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Note: `pnpm build` fails locally on Node v22.17.0 before `obuild` runs because the package script invokes `node src/cli.ts` directly. The repository CI uses `setup-node` with `lts/*`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI input normalization to properly handle comma-separated values, whitespace trimming, and empty value filtering for more robust input processing.

* **Bug Fixes**
  * Fixed input path resolution to filter and process only regular files, excluding directories from input lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->